### PR TITLE
Fix dependency issues when compiling without libraries due to shutdown of code.google.com

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,6 @@ golang-crosscompile:
 	git clone https://github.com/davecheney/golang-crosscompile.git
 
 deps:
-	go get code.google.com/p/go.net/websocket
-	go get code.google.com/p/go-uuid/uuid
-	go get code.google.com/p/gcfg
+	go get golang.org/x/net/websocket
+	go get github.com/pborman/uuid
+	go get gopkg.in/gcfg.v1

--- a/client.go
+++ b/client.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"bytes"
-	"code.google.com/p/go.net/websocket"
+	"golang.org/x/net/websocket"
 	"crypto/tls"
 	"encoding/json"
-	"code.google.com/p/go-uuid/uuid"
+	"github.com/pborman/uuid"
 	"flag"
 	"fmt"
 	"io"

--- a/config.go
+++ b/config.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"code.google.com/p/gcfg"
+	"gopkg.in/gcfg.v1"
 	"os"
 	"fmt"
 )

--- a/editsocket.go
+++ b/editsocket.go
@@ -4,7 +4,7 @@ import (
         "fmt"
         "encoding/json"
         "errors"
-        "code.google.com/p/go.net/websocket"
+        "golang.org/x/net/websocket"
 )
 
 

--- a/server.go
+++ b/server.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"bytes"
 	"encoding/json"
-	"code.google.com/p/go.net/websocket"
+	"golang.org/x/net/websocket"
 	"runtime"
 )
 

--- a/zedrem.go
+++ b/zedrem.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"os"
-	"code.google.com/p/go-uuid/uuid"
+	"github.com/pborman/uuid"
 	"strings"
 	"fmt"
 )


### PR DESCRIPTION
Rewrite imports to use new sources now that code.google.com has shutdown.  Otherwise compilation fails on a fresh install.
